### PR TITLE
Add driver location index

### DIFF
--- a/driver-location-service/build.gradle.kts
+++ b/driver-location-service/build.gradle.kts
@@ -7,4 +7,6 @@ application {
     mainClass.set("com.rideservice.location.DriverLocationServiceKt")
 }
 
-dependencies {}
+dependencies {
+    implementation("com.uber:h3:3.7.2")
+}

--- a/driver-location-service/src/main/kotlin/com/rideservice/location/DriverLocationIndex.kt
+++ b/driver-location-service/src/main/kotlin/com/rideservice/location/DriverLocationIndex.kt
@@ -1,0 +1,52 @@
+package com.rideservice.location
+
+import com.uber.h3core.H3Core
+
+/**
+ * Indexes driver locations using Uber's H3 library.
+ */
+class DriverLocationIndex(private val h3: H3Core = H3Core.newInstance()) {
+    private val indexToDrivers: MutableMap<Long, MutableSet<String>> = mutableMapOf()
+    private val driverToIndex: MutableMap<String, Long> = mutableMapOf()
+
+    /**
+     * Maps latitude and longitude to an H3 index using resolution 9.
+     */
+    fun latLngToIndex(lat: Double, lng: Double, resolution: Int = 9): Long =
+        h3.geoToH3(lat, lng, resolution)
+
+    /**
+     * Updates the stored location for a driver.
+     */
+    fun updateDriverLocation(driverId: String, lat: Double, lng: Double) {
+        val newIndex = latLngToIndex(lat, lng)
+        val oldIndex = driverToIndex.put(driverId, newIndex)
+
+        if (oldIndex != null && oldIndex != newIndex) {
+            indexToDrivers[oldIndex]?.let { drivers ->
+                drivers.remove(driverId)
+                if (drivers.isEmpty()) {
+                    indexToDrivers.remove(oldIndex)
+                }
+            }
+        }
+
+        indexToDrivers.computeIfAbsent(newIndex) { mutableSetOf() }.add(driverId)
+    }
+
+    /**
+     * Retrieves IDs of drivers near a location. The search radius is controlled
+     * by the kRing value which defaults to 1.
+     */
+    fun getDriversNear(lat: Double, lng: Double, kRing: Int = 1): Set<String> {
+        val center = latLngToIndex(lat, lng)
+        val indexes = h3.kRing(center, kRing)
+        val result = mutableSetOf<String>()
+
+        for (idx in indexes) {
+            indexToDrivers[idx]?.let { result.addAll(it) }
+        }
+
+        return result
+    }
+}


### PR DESCRIPTION
## Summary
- index driver locations using Uber's H3 library
- maintain driver->H3 and H3->drivers map
- expose APIs to update driver location and query nearby drivers
- pull Uber's h3 dependency into driver-location-service module

## Testing
- `gradle build` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm'] not found because of network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685cdc9f63108321a1e1ceb6ea2cf64e