### PR TITLE
Add Dockerfile for ride API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Build stage - use Gradle with JDK to compile the project
+FROM gradle:8-jdk17 AS build
+WORKDIR /app
+COPY . .
+RUN gradle :ride-api:installDist --no-daemon
+
+# Runtime image using Kotlin JDK
+FROM kotlin:latest-jdk
+WORKDIR /app
+COPY --from=build /app/ride-api/build/install/ride-api/ .
+EXPOSE 8080
+CMD ["bin/ride-api"]


### PR DESCRIPTION
## Summary
- add Dockerfile that builds the Kotlin project with Gradle and exposes the REST port

## Testing
- `gradle build` *(fails: Plugin resolution requires network)*

------
https://chatgpt.com/codex/tasks/task_e_685ce4081950832181dcad8fbff16a70