### PR TITLE
Add surge pricing engine

### DIFF
--- a/dispatch-service/src/main/kotlin/com/rideservice/simulator/RideBookingSimulator.kt
+++ b/dispatch-service/src/main/kotlin/com/rideservice/simulator/RideBookingSimulator.kt
@@ -3,6 +3,7 @@ package com.rideservice.simulator
 import com.rideservice.dispatch.Dispatcher
 import com.rideservice.location.DriverLocationIndex
 import com.rideservice.fare.FareEstimator
+import com.rideservice.fare.SurgeEngine
 import kotlin.random.Random
 
 /**
@@ -12,7 +13,8 @@ import kotlin.random.Random
 fun main() {
     val locationIndex = DriverLocationIndex()
     val dispatcher = Dispatcher(locationIndex)
-    val fareEstimator = FareEstimator()
+    val surgeEngine = SurgeEngine()
+    val fareEstimator = FareEstimator(surgeEngine = surgeEngine)
 
     // Generate mock drivers
     val categories = listOf("Go", "Sedan", "SUV")
@@ -37,7 +39,13 @@ fun main() {
     // Estimate fare
     val distanceKm = haversine(pickupLat, pickupLng, dropLat, dropLng)
     val durationMin = (distanceKm / 40.0) * 60.0
-    val fare = fareEstimator.estimateFare(distanceKm, durationMin, category)
+    val fare = fareEstimator.estimateFare(
+        distanceKm,
+        durationMin,
+        category,
+        pickupLat = pickupLat,
+        pickupLng = pickupLng
+    )
     println("Fare estimated: %.2f".format(fare))
 
     // Nearby drivers

--- a/fare-estimator/build.gradle.kts
+++ b/fare-estimator/build.gradle.kts
@@ -10,4 +10,5 @@ application {
 
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+    implementation("com.uber:h3:3.7.2")
 }

--- a/fare-estimator/src/main/kotlin/com/rideservice/fare/SurgeEngine.kt
+++ b/fare-estimator/src/main/kotlin/com/rideservice/fare/SurgeEngine.kt
@@ -1,0 +1,35 @@
+package com.rideservice.fare
+
+import com.uber.h3core.H3Core
+import kotlin.random.Random
+
+/**
+ * Simple engine that simulates surge pricing based on demand and supply per H3 cell.
+ * The surge factor is calculated as `1 + (demand / supply)` and stored in-memory.
+ */
+class SurgeEngine(private val h3: H3Core = H3Core.newInstance()) {
+    private val surgeMap: MutableMap<Long, Double> = mutableMapOf()
+
+    /**
+     * Returns the surge multiplier for a given latitude and longitude. Random
+     * demand and supply values are generated on each call to mimic fluctuations.
+     */
+    fun getSurgeMultiplier(lat: Double, lng: Double, resolution: Int = 9): Double {
+        val cellId = h3.geoToH3(lat, lng, resolution)
+        return getSurgeMultiplier(cellId)
+    }
+
+    /**
+     * Returns the surge multiplier for a specific H3 cell.
+     */
+    fun getSurgeMultiplier(cellId: Long): Double {
+        val demand = Random.nextInt(0, 20)
+        val supply = Random.nextInt(1, 20)
+        val factor = 1.0 + demand.toDouble() / supply.toDouble()
+        surgeMap[cellId] = factor
+        return factor
+    }
+
+    /** Exposes the current surge factors for inspection. */
+    fun currentSurgeMap(): Map<Long, Double> = surgeMap
+}

--- a/ride-api/src/main/kotlin/com/rideservice/api/RideApi.kt
+++ b/ride-api/src/main/kotlin/com/rideservice/api/RideApi.kt
@@ -2,6 +2,7 @@ package com.rideservice.api
 
 import com.rideservice.dispatch.Dispatcher
 import com.rideservice.fare.FareEstimator
+import com.rideservice.fare.SurgeEngine
 import io.ktor.server.application.*
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
@@ -42,7 +43,8 @@ fun Application.module() {
     install(Koin) {
         modules(
             module {
-                single { FareEstimator() }
+                single { SurgeEngine() }
+                single { FareEstimator(surgeEngine = get()) }
                 single { Dispatcher() }
             }
         )
@@ -54,7 +56,13 @@ fun Application.module() {
             val fareEstimator: FareEstimator by inject(FareEstimator::class.java)
             val distance = 10.0
             val duration = 20.0
-            val fare = fareEstimator.estimateFare(distance, duration, req.category)
+            val fare = fareEstimator.estimateFare(
+                distance,
+                duration,
+                req.category,
+                pickupLat = req.pickupLat,
+                pickupLng = req.pickupLng
+            )
             call.respond(FareEstimateResponse(fare))
         }
 


### PR DESCRIPTION
## Summary
- implement `SurgeEngine` for surge pricing per H3 cell
- use surge in fare calculation
- wire surge into API and simulator
- add h3 dependency for fare-estimator module

## Testing
- `gradle build` *(fails: Plugin org.jetbrains.kotlin.jvm not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce4ef68b08321aca898b108232375