### PR TITLE
Add unit tests for core modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,3 +7,14 @@ allprojects {
         mavenCentral()
     }
 }
+
+subprojects {
+    dependencies {
+        testImplementation(kotlin("test"))
+        testImplementation("io.kotest:kotest-assertions-core:5.8.1")
+    }
+
+    tasks.withType<Test> {
+        useJUnitPlatform()
+    }
+}

--- a/dispatch-service/src/main/kotlin/com/rideservice/dispatch/Dispatcher.kt
+++ b/dispatch-service/src/main/kotlin/com/rideservice/dispatch/Dispatcher.kt
@@ -15,7 +15,10 @@ import java.util.concurrent.locks.ReentrantLock
  * Simple dispatcher that selects the best driver for a ride request.
  * Uses dummy driver data and mocked ETA/distance calculations.
  */
-class Dispatcher(private val locationIndex: DriverLocationIndex = DriverLocationIndex()) {
+class Dispatcher(
+    private val locationIndex: DriverLocationIndex = DriverLocationIndex(),
+    private val random: Random = Random.Default
+) {
 
     data class Driver(
         val id: String,
@@ -118,7 +121,7 @@ class Dispatcher(private val locationIndex: DriverLocationIndex = DriverLocation
         val threads = sorted.map { (driver, _) ->
             thread(start = true) {
                 // Random delay simulating driver's response time
-                val delay = Random.nextLong(timeoutMs)
+                val delay = random.nextLong(timeoutMs)
                 Thread.sleep(delay)
 
                 // Check if someone already accepted
@@ -129,7 +132,7 @@ class Dispatcher(private val locationIndex: DriverLocationIndex = DriverLocation
                     lock.unlock()
                 }
 
-                if (Random.nextBoolean()) {
+                if (random.nextBoolean()) {
                     lock.lock()
                     try {
                         if (accepted == null) {

--- a/dispatch-service/src/test/kotlin/com/rideservice/dispatch/DispatcherTest.kt
+++ b/dispatch-service/src/test/kotlin/com/rideservice/dispatch/DispatcherTest.kt
@@ -1,0 +1,60 @@
+package com.rideservice.dispatch
+
+import com.rideservice.location.DriverLocationIndex
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class DispatcherTest {
+    private class BooleanRandom(private val values: MutableList<Boolean>) : Random() {
+        override fun nextBits(bitCount: Int): Int {
+            if (bitCount == 1 && values.isNotEmpty()) {
+                return if (values.removeAt(0)) 1 else 0
+            }
+            return 0
+        }
+    }
+
+    @Test
+    fun noDriversReturnsNull() {
+        val dispatcher = Dispatcher(DriverLocationIndex(), random = BooleanRandom(mutableListOf()))
+        val req = Dispatcher.RideRequest(0.0, 0.0, "Sedan")
+        assertNull(dispatcher.dispatch(req))
+    }
+
+    @Test
+    fun unicastSelectsClosestDriver() {
+        val index = DriverLocationIndex()
+        val dispatcher = Dispatcher(index, random = BooleanRandom(mutableListOf()))
+        dispatcher.registerDriver(Dispatcher.Driver("d1", 1.0, 1.0, "Sedan", 4.5))
+        dispatcher.registerDriver(Dispatcher.Driver("d2", 2.0, 2.0, "Sedan", 5.0))
+        val req = Dispatcher.RideRequest(1.0, 1.0, "Sedan")
+        val result = dispatcher.dispatch(req)
+        assertNotNull(result)
+        assertEquals("d1", result.id)
+    }
+
+    @Test
+    fun multicastAllRejectReturnsNull() {
+        val index = DriverLocationIndex()
+        val dispatcher = Dispatcher(index, random = BooleanRandom(mutableListOf(false, false)))
+        dispatcher.registerDriver(Dispatcher.Driver("d1", 1.0, 1.0, "Sedan", 4.5))
+        dispatcher.registerDriver(Dispatcher.Driver("d2", 1.0, 1.0005, "Sedan", 4.0))
+        val req = Dispatcher.RideRequest(1.0, 1.0, "Sedan")
+        val result = dispatcher.dispatchMulticast(req, maxCandidates = 2, timeoutMs = 100)
+        assertNull(result)
+    }
+
+    @Test
+    fun multicastReturnsFirstAcceptingDriver() {
+        val index = DriverLocationIndex()
+        val dispatcher = Dispatcher(index, random = BooleanRandom(mutableListOf(true)))
+        dispatcher.registerDriver(Dispatcher.Driver("d1", 1.0, 1.0, "Sedan", 4.5))
+        val req = Dispatcher.RideRequest(1.0, 1.0, "Sedan")
+        val result = dispatcher.dispatchMulticast(req, maxCandidates = 1, timeoutMs = 100)
+        assertNotNull(result)
+        assertEquals("d1", result.id)
+    }
+}

--- a/driver-location-service/src/test/kotlin/com/rideservice/location/DriverLocationIndexTest.kt
+++ b/driver-location-service/src/test/kotlin/com/rideservice/location/DriverLocationIndexTest.kt
@@ -1,0 +1,33 @@
+package com.rideservice.location
+
+import com.uber.h3core.H3Core
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DriverLocationIndexTest {
+    @Test
+    fun latLngToIndexMatchesH3() {
+        val index = DriverLocationIndex()
+        val h3 = H3Core.newInstance()
+        val lat = 12.9611
+        val lng = 77.6387
+        assertEquals(h3.geoToH3(lat, lng, 9), index.latLngToIndex(lat, lng))
+    }
+
+    @Test
+    fun kRingSearchFindsNearbyDrivers() {
+        val index = DriverLocationIndex()
+        index.updateDriverLocation("d1", 12.9611, 77.6387)
+        index.updateDriverLocation("d2", 12.9612, 77.6387)
+        index.updateDriverLocation("d3", 0.0, 0.0)
+
+        val nearby = index.getDriversNear(12.9611, 77.6387, 1)
+        assertTrue("d1" in nearby)
+        assertTrue("d2" in nearby)
+        assertTrue("d3" !in nearby)
+
+        val none = index.getDriversNear(89.0, 179.0, 1)
+        assertTrue(none.isEmpty())
+    }
+}

--- a/fare-estimator/src/main/kotlin/com/rideservice/fare/SurgeEngine.kt
+++ b/fare-estimator/src/main/kotlin/com/rideservice/fare/SurgeEngine.kt
@@ -7,14 +7,17 @@ import kotlin.random.Random
  * Simple engine that simulates surge pricing based on demand and supply per H3 cell.
  * The surge factor is calculated as `1 + (demand / supply)` and stored in-memory.
  */
-class SurgeEngine(private val h3: H3Core = H3Core.newInstance()) {
+open class SurgeEngine(
+    private val h3: H3Core = H3Core.newInstance(),
+    private val random: Random = Random.Default
+) {
     private val surgeMap: MutableMap<Long, Double> = mutableMapOf()
 
     /**
      * Returns the surge multiplier for a given latitude and longitude. Random
      * demand and supply values are generated on each call to mimic fluctuations.
      */
-    fun getSurgeMultiplier(lat: Double, lng: Double, resolution: Int = 9): Double {
+    open fun getSurgeMultiplier(lat: Double, lng: Double, resolution: Int = 9): Double {
         val cellId = h3.geoToH3(lat, lng, resolution)
         return getSurgeMultiplier(cellId)
     }
@@ -22,9 +25,9 @@ class SurgeEngine(private val h3: H3Core = H3Core.newInstance()) {
     /**
      * Returns the surge multiplier for a specific H3 cell.
      */
-    fun getSurgeMultiplier(cellId: Long): Double {
-        val demand = Random.nextInt(0, 20)
-        val supply = Random.nextInt(1, 20)
+    open fun getSurgeMultiplier(cellId: Long): Double {
+        val demand = random.nextInt(0, 20)
+        val supply = random.nextInt(1, 20)
         val factor = 1.0 + demand.toDouble() / supply.toDouble()
         surgeMap[cellId] = factor
         return factor

--- a/fare-estimator/src/test/kotlin/com/rideservice/fare/FareEstimatorTest.kt
+++ b/fare-estimator/src/test/kotlin/com/rideservice/fare/FareEstimatorTest.kt
@@ -1,0 +1,37 @@
+package com.rideservice.fare
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FareEstimatorTest {
+    private class StubSurgeEngine(private val factor: Double) : SurgeEngine() {
+        override fun getSurgeMultiplier(lat: Double, lng: Double, resolution: Int): Double = factor
+        override fun getSurgeMultiplier(cellId: Long): Double = factor
+    }
+
+    private val rateCard = mapOf("Test" to FareEstimator.Rate(base = 10.0, perKm = 2.0, perMin = 1.0))
+
+    @Test
+    fun surgeAppliedFromEngine() {
+        val estimator = FareEstimator(rateCard, StubSurgeEngine(2.0))
+        val fare = estimator.estimateFare(5.0, 10.0, "Test", pickupLat = 0.0, pickupLng = 0.0)
+        val expected = (10.0 + 5.0 * 2.0 + 10.0 * 1.0) * 2.0
+        assertEquals(expected, fare, 0.0001)
+    }
+
+    @Test
+    fun negativeMultiplierFallsBackToOne() {
+        val estimator = FareEstimator(rateCard, StubSurgeEngine(1.0))
+        val fare = estimator.estimateFare(5.0, 5.0, "Test", surgeMultiplier = -2.0)
+        val expected = 10.0 + 5.0 * 2.0 + 5.0 * 1.0
+        assertEquals(expected, fare, 0.0001)
+    }
+
+    @Test
+    fun highSurgeBeyondCapHandled() {
+        val estimator = FareEstimator(rateCard, StubSurgeEngine(5.0))
+        val fare = estimator.estimateFare(1.0, 0.0, "Test", pickupLat = 0.0, pickupLng = 0.0)
+        val expected = (10.0 + 1.0 * 2.0 + 0.0) * 5.0
+        assertEquals(expected, fare, 0.0001)
+    }
+}


### PR DESCRIPTION
## Summary
- make `SurgeEngine` extendable and inject `Random`
- allow injecting `Random` into `Dispatcher`
- configure common test dependencies
- add unit tests for fare estimation, dispatch logic and location index

## Testing
- `gradle test` *(fails: plugin could not be resolved due to no network access)*

------
https://chatgpt.com/codex/tasks/task_e_685ce66cad688321a7cc2708cdec25ba