### PR TITLE
Add booking runner for sample rides

### DIFF
--- a/booking-runner/build.gradle.kts
+++ b/booking-runner/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    application
+    kotlin("jvm")
+    kotlin("plugin.serialization")
+}
+
+application {
+    mainClass.set("com.rideservice.runner.BookingRunnerKt")
+}
+
+dependencies {
+    implementation(project(":driver-location-service"))
+    implementation(project(":dispatch-service"))
+    implementation(project(":fare-estimator"))
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+}

--- a/booking-runner/src/main/kotlin/com/rideservice/runner/BookingRunner.kt
+++ b/booking-runner/src/main/kotlin/com/rideservice/runner/BookingRunner.kt
@@ -1,0 +1,74 @@
+package com.rideservice.runner
+
+import com.rideservice.dispatch.Dispatcher
+import com.rideservice.location.DriverLocationIndex
+import com.rideservice.fare.FareEstimator
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import kotlin.math.*
+
+@Serializable
+data class DriverInput(val id: String, val lat: Double, val lng: Double, val category: String)
+
+@Serializable
+data class RideInput(
+    val pickup_lat: Double,
+    val pickup_lng: Double,
+    val drop_lat: Double,
+    val drop_lng: Double,
+    val category: String
+)
+
+fun main() {
+    val json = Json { ignoreUnknownKeys = true }
+
+    val driversText = BookingRunner::class.java.classLoader.getResource("drivers.json")?.readText()
+        ?: error("drivers.json not found")
+    val ridesText = BookingRunner::class.java.classLoader.getResource("rides.json")?.readText()
+        ?: error("rides.json not found")
+
+    val drivers = json.decodeFromString<List<DriverInput>>(driversText)
+    val rides = json.decodeFromString<List<RideInput>>(ridesText)
+
+    val locationIndex = DriverLocationIndex()
+    val dispatcher = Dispatcher(locationIndex)
+    val fareEstimator = FareEstimator()
+
+    // Index drivers
+    drivers.forEach { d ->
+        val driver = Dispatcher.Driver(d.id, d.lat, d.lng, d.category, rating = 4.5)
+        dispatcher.registerDriver(driver)
+    }
+
+    // Process rides
+    for (ride in rides) {
+        val distance = haversine(ride.pickup_lat, ride.pickup_lng, ride.drop_lat, ride.drop_lng)
+        val duration = (distance / 40.0) * 60.0
+        val fare = fareEstimator.estimateFare(
+            distance,
+            duration,
+            ride.category,
+            pickupLat = ride.pickup_lat,
+            pickupLng = ride.pickup_lng
+        )
+
+        val request = Dispatcher.RideRequest(ride.pickup_lat, ride.pickup_lng, ride.category)
+        val driver = dispatcher.dispatch(request)
+
+        if (driver != null) {
+            println("Matched driver ${'$'}{driver.id} for ride (${ride.pickup_lat},${ride.pickup_lng}) -> (${ride.drop_lat},${ride.drop_lng}) Fare: %.2f".format(fare))
+        } else {
+            println("No driver available for ride (${ride.pickup_lat},${ride.pickup_lng}) -> (${ride.drop_lat},${ride.drop_lng})")
+        }
+    }
+}
+
+private fun haversine(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
+    val R = 6371.0
+    val dLat = Math.toRadians(lat2 - lat1)
+    val dLon = Math.toRadians(lon2 - lon1)
+    val a = sin(dLat / 2).pow(2.0) + cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) * sin(dLon / 2).pow(2.0)
+    val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+    return R * c
+}

--- a/booking-runner/src/main/resources/drivers.json
+++ b/booking-runner/src/main/resources/drivers.json
@@ -1,0 +1,5 @@
+[
+  {"id": "d1", "lat": 12.961, "lng": 77.638, "category": "Sedan"},
+  {"id": "d2", "lat": 12.962, "lng": 77.639, "category": "Go"},
+  {"id": "d3", "lat": 12.963, "lng": 77.640, "category": "SUV"}
+]

--- a/booking-runner/src/main/resources/rides.json
+++ b/booking-runner/src/main/resources/rides.json
@@ -1,0 +1,4 @@
+[
+  {"pickup_lat": 12.9615, "pickup_lng": 77.6385, "drop_lat": 12.972, "drop_lng": 77.650, "category": "Sedan"},
+  {"pickup_lat": 12.960, "pickup_lng": 77.637, "drop_lat": 12.965, "drop_lng": 77.645, "category": "Go"}
+]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,5 +10,6 @@ include(
     "fare-estimator",
     "dispatch-service",
     "driver-location-service",
-    "ride-api"
+    "ride-api",
+    "booking-runner"
 )


### PR DESCRIPTION
## Summary
- add new `booking-runner` module
- load drivers and rides from JSON
- index drivers and dispatch them to rides while estimating fares
- provide example `drivers.json` and `rides.json`
- register module in settings

## Testing
- `gradle build` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm', version: '2.0.21'] was not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685ce853663c8321adc68eb526f103df