### PR TITLE
Fix subproject test config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,9 +10,13 @@ allprojects {
 }
 
 subprojects {
-    dependencies {
-        testImplementation(kotlin("test"))
-        testImplementation("io.kotest:kotest-assertions-core:5.8.1")
+    // Add test dependencies only after the Kotlin plugin is applied so that
+    // the 'testImplementation' configuration exists for each subproject.
+    plugins.withId("org.jetbrains.kotlin.jvm") {
+        dependencies {
+            testImplementation(kotlin("test"))
+            testImplementation("io.kotest:kotest-assertions-core:5.8.1")
+        }
     }
 
     tasks.withType<Test> {


### PR DESCRIPTION
## Summary
- ensure `testImplementation` dependencies are added only after the Kotlin plugin is applied

## Testing
- `gradle build` *(fails: Plugin was not found because of offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_685cee4b9b188321808b07423efb1943