### PR TITLE
Fix Kotlin serialization plugin configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     // Use a stable Kotlin version so IDEs can resolve the Gradle plugin
-    kotlin("jvm") version "1.9.22"
+    kotlin("jvm") version "1.9.22" apply false
+    kotlin("plugin.serialization") version "1.9.22" apply false
 }
 
 allprojects {


### PR DESCRIPTION
## Summary
- add versioned `kotlin("plugin.serialization")` plugin in the main Gradle build to ensure subprojects can apply it

## Testing
- `gradle build --no-daemon` *(fails: Plugin resolution requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_685cf0628a7483218ffd75b98eeeb177