### PR TITLE
Fix test dependencies in root gradle script

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,8 +15,8 @@ subprojects {
     // the 'testImplementation' configuration exists for each subproject.
     plugins.withId("org.jetbrains.kotlin.jvm") {
         dependencies {
-            testImplementation(kotlin("test"))
-            testImplementation("io.kotest:kotest-assertions-core:5.8.1")
+            add("testImplementation", kotlin("test"))
+            add("testImplementation", "io.kotest:kotest-assertions-core:5.8.1")
         }
     }
 


### PR DESCRIPTION
## Summary
- fix `testImplementation` compile error using `add` method

## Testing
- `gradle test --no-daemon` *(fails: Plugin org.jetbrains.kotlin.jvm could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_685cf12f33d88321a05069ce0edb011c