### PR TITLE
Fix build errors for BookingRunner and API deps

### DIFF
--- a/booking-runner/src/main/kotlin/com/rideservice/runner/BookingRunner.kt
+++ b/booking-runner/src/main/kotlin/com/rideservice/runner/BookingRunner.kt
@@ -23,9 +23,9 @@ data class RideInput(
 fun main() {
     val json = Json { ignoreUnknownKeys = true }
 
-    val driversText = BookingRunner::class.java.classLoader.getResource("drivers.json")?.readText()
+    val driversText = BookingRunnerKt::class.java.classLoader.getResource("drivers.json")?.readText()
         ?: error("drivers.json not found")
-    val ridesText = BookingRunner::class.java.classLoader.getResource("rides.json")?.readText()
+    val ridesText = BookingRunnerKt::class.java.classLoader.getResource("rides.json")?.readText()
         ?: error("rides.json not found")
 
     val drivers = json.decodeFromString<List<DriverInput>>(driversText)

--- a/dispatch-service/build.gradle.kts
+++ b/dispatch-service/build.gradle.kts
@@ -8,7 +8,7 @@ application {
 }
 
 dependencies {
-    implementation(project(":driver-location-service"))
+    api(project(":driver-location-service"))
     implementation(project(":fare-estimator"))
     implementation("com.uber:h3:3.7.2")
 }

--- a/driver-location-service/build.gradle.kts
+++ b/driver-location-service/build.gradle.kts
@@ -8,5 +8,5 @@ application {
 }
 
 dependencies {
-    implementation("com.uber:h3:3.7.2")
+    api("com.uber:h3:3.7.2")
 }


### PR DESCRIPTION
## Summary
- fix reference to generated `BookingRunnerKt` class
- expose driver location service and H3 dependency so downstream modules compile

## Testing
- `gradle build --offline` *(fails: Plugin org.jetbrains.kotlin.jvm not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cf33d93b883218f4173c9630a969b