### PR TITLE
Fix resource loading in BookingRunner

### DIFF
--- a/booking-runner/src/main/kotlin/com/rideservice/runner/BookingRunner.kt
+++ b/booking-runner/src/main/kotlin/com/rideservice/runner/BookingRunner.kt
@@ -23,9 +23,9 @@ data class RideInput(
 fun main() {
     val json = Json { ignoreUnknownKeys = true }
 
-    val driversText = BookingRunnerKt::class.java.classLoader.getResource("drivers.json")?.readText()
+    val driversText = object {}.javaClass.classLoader.getResource("drivers.json")?.readText()
         ?: error("drivers.json not found")
-    val ridesText = BookingRunnerKt::class.java.classLoader.getResource("rides.json")?.readText()
+    val ridesText = object {}.javaClass.classLoader.getResource("rides.json")?.readText()
         ?: error("rides.json not found")
 
     val drivers = json.decodeFromString<List<DriverInput>>(driversText)


### PR DESCRIPTION
## Summary
- fix BookingRunner to load resources without referencing BookingRunnerKt

## Testing
- `gradle build` *(fails: could not resolve Kotlin plugin)*

------
https://chatgpt.com/codex/tasks/task_e_685cf456add08321879dfb7db35644a0