### PR TITLE
Implement fare rounding

### DIFF
--- a/fare-estimator/src/main/kotlin/com/rideservice/fare/FareEstimator.kt
+++ b/fare-estimator/src/main/kotlin/com/rideservice/fare/FareEstimator.kt
@@ -3,6 +3,7 @@ package com.rideservice.fare
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import kotlin.math.ceil
 
 /**
  * Provides fare estimation for different ride categories using a configurable rate card.
@@ -50,7 +51,7 @@ class FareEstimator(
 
         val fare = (rate.base + (distanceInKm * rate.perKm) + (durationInMinutes * rate.perMin)) * multiplier
         println("Calculated fare amount: ${'$'}fare")
-        return fare
+        return ceil(fare)
     }
 }
 

--- a/fare-estimator/src/test/kotlin/com/rideservice/fare/FareEstimatorTest.kt
+++ b/fare-estimator/src/test/kotlin/com/rideservice/fare/FareEstimatorTest.kt
@@ -34,4 +34,12 @@ class FareEstimatorTest {
         val expected = (10.0 + 1.0 * 2.0 + 0.0) * 5.0
         assertEquals(expected, fare, 0.0001)
     }
+
+    @Test
+    fun fractionalFareRoundsUp() {
+        val estimator = FareEstimator(rateCard, StubSurgeEngine(1.0))
+        val fare = estimator.estimateFare(5.5, 3.2, "Test")
+        val expected = 25.0
+        assertEquals(expected, fare, 0.0001)
+    }
 }


### PR DESCRIPTION
## Summary
- round up fare estimates to the next integer
- verify rounding with a new unit test

## Testing
- `gradle test` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm'] not found due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_685d08f6d3c48321bfe76b6a225ba126