### PR TITLE
Fix simulator driver matches

### DIFF
--- a/dispatch-service/src/main/kotlin/com/rideservice/simulator/RideBookingSimulator.kt
+++ b/dispatch-service/src/main/kotlin/com/rideservice/simulator/RideBookingSimulator.kt
@@ -12,7 +12,9 @@ import kotlin.math.pow
  * modules in this repository.
  */
 fun main() {
-    val locationIndex = DriverLocationIndex()
+    // Use a coarser resolution to cover a wider area so that our random drivers
+    // fall within the same search cells as the ride request
+    val locationIndex = DriverLocationIndex(resolution = 8)
     val dispatcher = Dispatcher(locationIndex)
     val surgeEngine = SurgeEngine()
     val fareEstimator = FareEstimator(surgeEngine = surgeEngine)
@@ -50,7 +52,8 @@ fun main() {
     println("Fare estimated: %.2f".format(fare))
 
     // Nearby drivers
-    val nearby = locationIndex.getDriversNear(pickupLat, pickupLng)
+    // Use a larger search radius so the simulator consistently finds nearby drivers
+    val nearby = locationIndex.getDriversNear(pickupLat, pickupLng, kRing = 2)
     println("Nearby drivers found: ${nearby.joinToString()}")
 
     // Dispatch driver (set to true for multicast mode)

--- a/driver-location-service/src/main/kotlin/com/rideservice/location/DriverLocationIndex.kt
+++ b/driver-location-service/src/main/kotlin/com/rideservice/location/DriverLocationIndex.kt
@@ -5,14 +5,17 @@ import com.uber.h3core.H3Core
 /**
  * Indexes driver locations using Uber's H3 library.
  */
-class DriverLocationIndex(private val h3: H3Core = H3Core.newInstance()) {
+class DriverLocationIndex(
+    private val h3: H3Core = H3Core.newInstance(),
+    private val resolution: Int = 9
+) {
     private val indexToDrivers: MutableMap<Long, MutableSet<String>> = mutableMapOf()
     private val driverToIndex: MutableMap<String, Long> = mutableMapOf()
 
     /**
      * Maps latitude and longitude to an H3 index using resolution 9.
      */
-    fun latLngToIndex(lat: Double, lng: Double, resolution: Int = 9): Long =
+    fun latLngToIndex(lat: Double, lng: Double, resolution: Int = this.resolution): Long =
         h3.geoToH3(lat, lng, resolution)
 
     /**


### PR DESCRIPTION
## Summary
- allow configuring H3 resolution inside `DriverLocationIndex`
- use coarser resolution in `RideBookingSimulator`
- expand search radius when listing nearby drivers

## Testing
- `gradle :dispatch-service:run` *(fails: plugin download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685d25cddce083218026f4144a3a4977