### PR TITLE
Add sample drivers and rides

### DIFF
--- a/booking-runner/src/main/resources/drivers.json
+++ b/booking-runner/src/main/resources/drivers.json
@@ -1,5 +1,17 @@
 [
   {"id": "d1", "lat": 12.961, "lng": 77.638, "category": "Sedan"},
   {"id": "d2", "lat": 12.962, "lng": 77.639, "category": "Go"},
-  {"id": "d3", "lat": 12.963, "lng": 77.640, "category": "SUV"}
+  {"id": "d3", "lat": 12.963, "lng": 77.640, "category": "SUV"},
+  {"id": "d4", "lat": 12.965, "lng": 77.639, "category": "SUV"},
+  {"id": "d5", "lat": 12.966, "lng": 77.642, "category": "Go"},
+  {"id": "d6", "lat": 12.9675, "lng": 77.6405, "category": "Sedan"},
+  {"id": "d7", "lat": 12.9683, "lng": 77.6375, "category": "Go"},
+  {"id": "d8", "lat": 12.9695, "lng": 77.6382, "category": "SUV"},
+  {"id": "d9", "lat": 12.9700, "lng": 77.6412, "category": "Sedan"},
+  {"id": "d10", "lat": 12.9710, "lng": 77.6398, "category": "Go"},
+  {"id": "d11", "lat": 12.9725, "lng": 77.6401, "category": "SUV"},
+  {"id": "d12", "lat": 12.9735, "lng": 77.6425, "category": "Sedan"},
+  {"id": "d13", "lat": 12.974, "lng": 77.638, "category": "Go"},
+  {"id": "d14", "lat": 12.975, "lng": 77.6395, "category": "SUV"},
+  {"id": "d15", "lat": 12.976, "lng": 77.6415, "category": "Sedan"}
 ]

--- a/booking-runner/src/main/resources/rides.json
+++ b/booking-runner/src/main/resources/rides.json
@@ -1,4 +1,7 @@
 [
   {"pickup_lat": 12.9615, "pickup_lng": 77.6385, "drop_lat": 12.972, "drop_lng": 77.650, "category": "Sedan"},
-  {"pickup_lat": 12.960, "pickup_lng": 77.637, "drop_lat": 12.965, "drop_lng": 77.645, "category": "Go"}
+  {"pickup_lat": 12.960, "pickup_lng": 77.637, "drop_lat": 12.965, "drop_lng": 77.645, "category": "Go"},
+  {"pickup_lat": 12.966, "pickup_lng": 77.640, "drop_lat": 12.973, "drop_lng": 77.646, "category": "SUV"},
+  {"pickup_lat": 12.970, "pickup_lng": 77.638, "drop_lat": 12.975, "drop_lng": 77.643, "category": "Sedan"},
+  {"pickup_lat": 12.968, "pickup_lng": 77.642, "drop_lat": 12.978, "drop_lng": 77.649, "category": "Go"}
 ]

--- a/ride-api/src/main/kotlin/com/rideservice/api/RideApi.kt
+++ b/ride-api/src/main/kotlin/com/rideservice/api/RideApi.kt
@@ -58,6 +58,18 @@ fun Application.module() {
     dispatcher.registerDriver(Dispatcher.Driver("d1", 12.9611, 77.6387, "Sedan", 4.5))
     dispatcher.registerDriver(Dispatcher.Driver("d2", 12.9620, 77.6410, "Go", 4.8))
     dispatcher.registerDriver(Dispatcher.Driver("d3", 12.9640, 77.6400, "Sedan", 4.2))
+    dispatcher.registerDriver(Dispatcher.Driver("d4", 12.9650, 77.6390, "SUV", 4.6))
+    dispatcher.registerDriver(Dispatcher.Driver("d5", 12.9660, 77.6420, "Go", 4.3))
+    dispatcher.registerDriver(Dispatcher.Driver("d6", 12.9675, 77.6405, "Sedan", 4.9))
+    dispatcher.registerDriver(Dispatcher.Driver("d7", 12.9683, 77.6375, "Go", 4.1))
+    dispatcher.registerDriver(Dispatcher.Driver("d8", 12.9695, 77.6382, "SUV", 4.4))
+    dispatcher.registerDriver(Dispatcher.Driver("d9", 12.9700, 77.6412, "Sedan", 4.7))
+    dispatcher.registerDriver(Dispatcher.Driver("d10", 12.9710, 77.6398, "Go", 4.0))
+    dispatcher.registerDriver(Dispatcher.Driver("d11", 12.9725, 77.6401, "SUV", 4.5))
+    dispatcher.registerDriver(Dispatcher.Driver("d12", 12.9735, 77.6425, "Sedan", 4.6))
+    dispatcher.registerDriver(Dispatcher.Driver("d13", 12.9740, 77.6380, "Go", 4.8))
+    dispatcher.registerDriver(Dispatcher.Driver("d14", 12.9750, 77.6395, "SUV", 4.2))
+    dispatcher.registerDriver(Dispatcher.Driver("d15", 12.9760, 77.6415, "Sedan", 4.7))
 
     routing {
         post("/fare/estimate") {


### PR DESCRIPTION
## Summary
- add sample drivers to RideApi
- extend `drivers.json` with more drivers
- extend `rides.json` with more sample rides

## Testing
- `gradle test` *(fails: plugin resolution requires network)*

------
https://chatgpt.com/codex/tasks/task_e_685d312817288321bfd5c1da6999d1ca