### PR TITLE
Update surge engine to account for drop location

### DIFF
--- a/booking-runner/src/main/kotlin/com/rideservice/runner/BookingRunner.kt
+++ b/booking-runner/src/main/kotlin/com/rideservice/runner/BookingRunner.kt
@@ -52,7 +52,9 @@ fun main() {
             duration,
             ride.category,
             pickupLat = ride.pickup_lat,
-            pickupLng = ride.pickup_lng
+            pickupLng = ride.pickup_lng,
+            dropLat = ride.drop_lat,
+            dropLng = ride.drop_lng
         )
 
         val request = Dispatcher.RideRequest(ride.pickup_lat, ride.pickup_lng, ride.category)

--- a/dispatch-service/src/main/kotlin/com/rideservice/simulator/RideBookingSimulator.kt
+++ b/dispatch-service/src/main/kotlin/com/rideservice/simulator/RideBookingSimulator.kt
@@ -47,7 +47,9 @@ fun main() {
         durationMin,
         category,
         pickupLat = pickupLat,
-        pickupLng = pickupLng
+        pickupLng = pickupLng,
+        dropLat = dropLat,
+        dropLng = dropLng
     )
     println("Fare estimated: %.2f".format(fare))
 

--- a/fare-estimator/src/main/kotlin/com/rideservice/fare/FareEstimator.kt
+++ b/fare-estimator/src/main/kotlin/com/rideservice/fare/FareEstimator.kt
@@ -30,7 +30,9 @@ class FareEstimator(
         category: String,
         surgeMultiplier: Double = 1.0,
         pickupLat: Double? = null,
-        pickupLng: Double? = null
+        pickupLng: Double? = null,
+        dropLat: Double? = null,
+        dropLng: Double? = null
     ): Double {
         println("Estimating fare: distance=$distanceInKm km, duration=$durationInMinutes min, category=$category")
         require(distanceInKm >= 0) { "distanceInKm must be non-negative" }
@@ -41,7 +43,13 @@ class FareEstimator(
 
         // When pickup location is known, consult the surge engine for that area
         val surgeFactor = if (pickupLat != null && pickupLng != null) {
-            surgeEngine.getSurgeMultiplier(pickupLat, pickupLng)
+            surgeEngine.getSurgeMultiplier(
+                pickupLat,
+                pickupLng,
+                dropLat,
+                dropLng,
+                category
+            )
         } else {
             // No surge applied without a pickup position
             1.0

--- a/fare-estimator/src/main/kotlin/com/rideservice/fare/SurgeEngine.kt
+++ b/fare-estimator/src/main/kotlin/com/rideservice/fare/SurgeEngine.kt
@@ -14,29 +14,70 @@ open class SurgeEngine(
     private val surgeMap: MutableMap<Long, Double> = mutableMapOf()
 
     /**
-     * Returns the surge multiplier for a given latitude and longitude. Random
-     * demand and supply values are generated on each call to mimic fluctuations.
+     * Returns the surge multiplier for a pickup and optional drop location.
+     * Demand and supply are randomly generated for each cell to simulate
+     * changing conditions. When the drop location is provided, the surge factor
+     * is adjusted inversely to the demand at that destination. Optionally the
+     * ride category can be provided which reduces available supply to mimic
+     * category specific scarcity.
      */
-    open fun getSurgeMultiplier(lat: Double, lng: Double, resolution: Int = 9): Double {
-        val cellId = h3.geoToH3(lat, lng, resolution)
-        // Delegate to the cell based overload so surge state is consistent
-        return getSurgeMultiplier(cellId)
+    open fun getSurgeMultiplier(
+        pickupLat: Double,
+        pickupLng: Double,
+        dropLat: Double? = null,
+        dropLng: Double? = null,
+        category: String? = null,
+        resolution: Int = 9
+    ): Double {
+        val pickupCell = h3.geoToH3(pickupLat, pickupLng, resolution)
+        val dropCell = if (dropLat != null && dropLng != null) {
+            h3.geoToH3(dropLat, dropLng, resolution)
+        } else {
+            null
+        }
+        return getSurgeMultiplier(pickupCell, dropCell, category)
     }
 
     /**
-     * Returns the surge multiplier for a specific H3 cell.
+     * Returns the surge multiplier for a specific H3 cell. When [dropCellId] or
+     * [category] are provided they influence the computation as described in the
+     * class documentation.
      */
-    open fun getSurgeMultiplier(cellId: Long): Double {
-        // Randomly derive demand and supply to keep the example simple
-        val demand = random.nextInt(0, 20)
-        val supply = random.nextInt(1, 20)
-        // Surge multiplier grows as demand exceeds supply
-        val factor = 1.0 + demand.toDouble() / supply.toDouble()
-        // Persist the last computed surge value so other components can inspect it
-        surgeMap[cellId] = factor
-        println("Surge calculation for cell $cellId -> demand=$demand, supply=$supply, factor=$factor")
+    open fun getSurgeMultiplier(
+        pickupCellId: Long,
+        dropCellId: Long? = null,
+        category: String? = null
+    ): Double {
+        val pickupDemand = random.nextInt(0, 20)
+        val pickupSupply = random.nextInt(1, 20)
+        val categorySupply = if (category != null) {
+            // Fewer cars of the requested category increases surge
+            random.nextInt(1, pickupSupply + 1)
+        } else {
+            pickupSupply
+        }
+
+        var factor = 1.0 + pickupDemand.toDouble() / categorySupply.toDouble()
+
+        if (dropCellId != null) {
+            val dropDemand = random.nextInt(0, 20)
+            val dropSupply = random.nextInt(1, 20)
+            val dropRatio = dropDemand.toDouble() / dropSupply.toDouble()
+            // Higher demand in the drop cell lowers surge and vice versa
+            factor += (1.0 - dropRatio)
+        }
+
+        surgeMap[pickupCellId] = factor
+        println(
+            "Surge calculation pickup=$pickupCellId drop=${dropCellId ?: "-"} " +
+                "factor=$factor"
+        )
         return factor
     }
+
+    /** Compatibility overload that only requires a single cell id. */
+    open fun getSurgeMultiplier(cellId: Long): Double =
+        getSurgeMultiplier(cellId, null, null)
 
     /** Exposes the current surge factors for inspection. */
     fun currentSurgeMap(): Map<Long, Double> = surgeMap

--- a/fare-estimator/src/test/kotlin/com/rideservice/fare/FareEstimatorTest.kt
+++ b/fare-estimator/src/test/kotlin/com/rideservice/fare/FareEstimatorTest.kt
@@ -5,8 +5,16 @@ import kotlin.test.assertEquals
 
 class FareEstimatorTest {
     private class StubSurgeEngine(private val factor: Double) : SurgeEngine() {
-        override fun getSurgeMultiplier(lat: Double, lng: Double, resolution: Int): Double = factor
-        override fun getSurgeMultiplier(cellId: Long): Double = factor
+        override fun getSurgeMultiplier(
+            pickupLat: Double,
+            pickupLng: Double,
+            dropLat: Double?,
+            dropLng: Double?,
+            category: String?,
+            resolution: Int
+        ): Double = factor
+
+        override fun getSurgeMultiplier(pickupCellId: Long, dropCellId: Long?, category: String?): Double = factor
     }
 
     private val rateCard = mapOf("Test" to FareEstimator.Rate(base = 10.0, perKm = 2.0, perMin = 1.0))

--- a/ride-api/src/main/kotlin/com/rideservice/api/RideApi.kt
+++ b/ride-api/src/main/kotlin/com/rideservice/api/RideApi.kt
@@ -84,7 +84,9 @@ fun Application.module() {
                 duration,
                 req.category,
                 pickupLat = req.pickupLat,
-                pickupLng = req.pickupLng
+                pickupLng = req.pickupLng,
+                dropLat = req.dropLat,
+                dropLng = req.dropLng
             )
             println("Calculated fare: %.2f".format(fare))
             call.respond(FareEstimateResponse(fare))


### PR DESCRIPTION
## Summary
- factor drop location and ride category into surge calculation
- pass drop lat/lon when estimating fares
- update simulator, booking runner and API
- adjust tests for new SurgeEngine API

## Testing
- `gradle test` *(fails: Plugin not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685e31425298832183f35847a422cdc4